### PR TITLE
GitHub CLI in de devcontainer + branchdiscipline in de rules

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(grep -v \"^$\")"
+    ]
+  }
+}

--- a/.cursor/rules/okx-governance.mdc
+++ b/.cursor/rules/okx-governance.mdc
@@ -20,3 +20,25 @@ Workflow regels:
 - Als iets een architectuurbesluit is, leg het vast als ADR in architecture/dr/ en link naar issues en notulen.
 - Meetings: vastleggen -> (optioneel) transcriberen -> samenvatten in architecture/meetings/. Notulen voeden issues en PR's.
 
+Branchdiscipline: 1 issue = 1 branch = 1 PR
+- Een branch hoort bij precies EEN issue. Vertrek vanaf `dev`, PR terug naar `dev`.
+- Houd branches KORT. Hoe langer een branch openstaat naast een bewegende `dev`,
+  hoe groter de merge-pijn - en bij `architecture/model/model.archimate` is die pijn
+  echt: dat bestand kan niet regelgebaseerd gemerged worden (zie ADR 0010).
+- Waarom dit ertoe doet (juli 2026): op een langlopende branch stapelden vijf
+  onderwerpen zich op. De merge met `dev` gaf een conflict op `model.archimate`, de
+  handmatige resolutie liet 276 element-definities wegvallen (295 dode verwijzingen,
+  9 views kapot), en het preventiewerk zat vervolgens vast in diezelfde brede PR
+  in plaats van het team meteen te beschermen.
+
+Wat ik (de agent) doe:
+- Ik houd bij welk issue bij de huidige branch hoort (vaak herkenbaar aan de branchnaam).
+- Zie ik werk ontstaan dat daar BUITEN valt - een ander domein, een nieuwe map, een
+  tweede onderwerp - dan BENOEM ik dat en VRAAG ik of het een eigen branch/issue moet
+  worden. Ik blokkeer niet en beslis niet voor je; jij kiest.
+- Kleine aanpalende bijvangst (typo, kapotte link, ontbrekende index-regel) meld ik
+  hooguit kort; daar maak ik geen punt van.
+- Is iets urgent en breed nuttig (bv. een guard of fix die het hele team beschermt),
+  dan stel ik voor het in een APARTE kleine PR te zetten, zodat het niet hoeft te
+  wachten op de review van breder werk.
+

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -27,7 +27,32 @@ cat /.dockerenv # bestaat -> je zit in een container
 
 - Python 3.12 + `pip` (zie [`requirements.txt`](requirements.txt), o.a. Pillow).
 - Node.js LTS + `npm` (via devcontainer-feature) + `markdownlint-cli2` + `mermaid-cli`.
+- **GitHub CLI (`gh`)** (via devcontainer-feature) - zie hieronder.
 - `imagemagick`, `graphviz`, `pandoc`, `chromium`.
+
+## GitHub vanuit de container (eenmalig inloggen)
+
+Zonder login kan de container **niet pushen** (`could not read Username for 'https://github.com'`)
+en kunnen agents geen PR's openen of reviewen. Log daarom na de eerste build eenmalig in:
+
+```bash
+gh auth login        # kies: GitHub.com -> HTTPS -> login met browser/device code
+gh auth setup-git    # maakt gh de git credential helper, zodat ook `git push` werkt
+```
+
+Controleren:
+
+```bash
+gh auth status
+git push --dry-run   # moet nu slagen zonder om een gebruikersnaam te vragen
+```
+
+De login wordt bewaard in een **named volume** (`okx-meta-gh-config`, gemount op
+`~/.config/gh`), dus je hoeft dit **niet** te herhalen na een `Rebuild Container`.
+
+Daarmee kunnen mens en agent hetzelfde: committen, pushen, PR's openen (`gh pr create`),
+reviewen en mergen - allemaal **binnen** de container, conform
+[`dev-omgeving.mdc`](../.cursor/rules/dev-omgeving.mdc).
 
 ## Extra tooling toevoegen (reproduceerbaar voor het team)
 
@@ -38,6 +63,7 @@ Installeer **niet** ad-hoc; voeg het toe aan de juiste plek en rebuild:
 | Python-pakket | [`requirements.txt`](requirements.txt) |
 | Systeem/CLI-tool | [`Dockerfile`](Dockerfile) |
 | Node-tool (globaal) | `postCreateCommand` in [`devcontainer.json`](devcontainer.json) |
+| CLI met eigen feature (bv. `gh`) | `features` in [`devcontainer.json`](devcontainer.json) |
 
 Daarna: commandpalet -> **`Dev Containers: Rebuild Container`**.
 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -28,6 +28,7 @@ cat /.dockerenv # bestaat -> je zit in een container
 - Python 3.12 + `pip` (zie [`requirements.txt`](requirements.txt), o.a. Pillow).
 - Node.js LTS + `npm` (via devcontainer-feature) + `markdownlint-cli2` + `mermaid-cli`.
 - **GitHub CLI (`gh`)** (via devcontainer-feature) - zie hieronder.
+- **Claude Code** (`Anthropic.claude-code`) - VS Code/Cursor-extensie; zie hieronder.
 - `imagemagick`, `graphviz`, `pandoc`, `chromium`.
 
 ## GitHub vanuit de container (eenmalig inloggen)
@@ -54,6 +55,12 @@ Daarmee kunnen mens en agent hetzelfde: committen, pushen, PR's openen (`gh pr c
 reviewen en mergen - allemaal **binnen** de container, conform
 [`dev-omgeving.mdc`](../.cursor/rules/dev-omgeving.mdc).
 
+## Claude Code (extensie)
+
+De extensie wordt automatisch geïnstalleerd bij **Rebuild Container**. Eenmalig inloggen
+via de Claude Code-sidebar in Cursor/VS Code (Anthropic-account of API key, afhankelijk
+van jullie licentie). Zie [Claude Code in VS Code](https://code.claude.com/docs/en/vscode).
+
 ## Extra tooling toevoegen (reproduceerbaar voor het team)
 
 Installeer **niet** ad-hoc; voeg het toe aan de juiste plek en rebuild:
@@ -63,6 +70,7 @@ Installeer **niet** ad-hoc; voeg het toe aan de juiste plek en rebuild:
 | Python-pakket | [`requirements.txt`](requirements.txt) |
 | Systeem/CLI-tool | [`Dockerfile`](Dockerfile) |
 | Node-tool (globaal) | `postCreateCommand` in [`devcontainer.json`](devcontainer.json) |
+| VS Code/Cursor-extensie | `customizations.vscode.extensions` in [`devcontainer.json`](devcontainer.json) |
 | CLI met eigen feature (bv. `gh`) | `features` in [`devcontainer.json`](devcontainer.json) |
 
 Daarna: commandpalet -> **`Dev Containers: Rebuild Container`**.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,17 +9,30 @@
     "context": "."
   },
 
-  // Node komt uit een devcontainer-feature (betrouwbaar beheerd).
+  // Node en de GitHub CLI komen uit devcontainer-features (betrouwbaar beheerd).
   "features": {
     "ghcr.io/devcontainers/features/node:1": {
       "version": "lts"
+    },
+    // gh: PR's openen, reviewen en mergen vanuit de container.
+    // Eenmalig na het (her)bouwen: `gh auth login`  -> daarna `gh auth setup-git`
+    // zodat ook `git push` werkt (gh wordt dan de credential helper).
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "latest"
     }
   },
+
+  // De gh-login blijft bewaard in een named volume, zodat je niet opnieuw hoeft
+  // in te loggen na elke "Rebuild Container".
+  "mounts": [
+    "source=okx-meta-gh-config,target=/home/vscode/.config/gh,type=volume"
+  ],
 
   // npm-tooling globaal installeren nadat Node beschikbaar is.
   // markdownlint-cli2 : linten van markdown docs
   // @mermaid-js/mermaid-cli : mermaid-diagrammen renderen (gebruikt de chromium uit de Dockerfile)
-  "postCreateCommand": "npm install -g markdownlint-cli2 @mermaid-js/mermaid-cli",
+  // De chown is nodig omdat een named volume als root wordt aangemaakt.
+  "postCreateCommand": "sudo chown -R vscode:vscode /home/vscode/.config/gh && npm install -g markdownlint-cli2 @mermaid-js/mermaid-cli",
 
   "containerEnv": {
     "PUPPETEER_SKIP_DOWNLOAD": "true",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,10 +41,12 @@
 
   "customizations": {
     "vscode": {
+      // Claude Code (Anthropic.claude-code): na Rebuild inloggen via de extensie (OAuth of API key).
       "extensions": [
         "DavidAnson.vscode-markdownlint",
         "bierner.markdown-mermaid",
-        "ms-python.python"
+        "ms-python.python",
+        "Anthropic.claude-code"
       ]
     }
   },


### PR DESCRIPTION
Fixes #111 

## Probleem
Vanuit de devcontainer kon niet gepusht worden en konden agents niet met GitHub
praten. Committen werkte wel, maar `git push` faalde op:

    could not read Username for 'https://github.com': No such device or address

Twee gaten: geen credentials in de container, en `gh` ontbrak.

## Oplossing
- Devcontainer-feature `github-cli` toegevoegd.
- De gh-login blijft bewaard in een named volume (`okx-meta-gh-config` op
  `~/.config/gh`), dus **geen herhaalde login na een rebuild**.
- README: eenmalig `gh auth login` + `gh auth setup-git`. Die tweede stap is de
  cruciale — die maakt gh de git credential helper, waardoor ook `git push` werkt.

Conform `dev-omgeving.mdc`: niets ad hoc geïnstalleerd, alles gedeclareerd in de
devcontainer.

## Ook meegenomen: branchdiscipline
`okx-governance.mdc` (alwaysApply) legt nu vast: **1 issue = 1 branch = 1 PR**,
vertrek vanaf `dev`, houd branches kort. Met de aanleiding erbij — op een
langlopende branch stapelden vijf onderwerpen zich op; de merge met `dev` gaf een
conflict op `model.archimate` en de handmatige resolutie liet 276 element-definities
wegvallen (295 dode verwijzingen, 9 views kapot).

Afgesproken agentgedrag: scope-afwijking **signaleren en doorvragen, niet blokkeren**.
Urgent en breed nuttig werk voorstellen als aparte kleine PR.

> Bewuste keuze: dit tweede onderwerp valt strikt genomen buiten #111. Toegevoegd
> omdat het hoort bij "agent-assisted development inrichten".

## Testen
1. `Dev Containers: Rebuild Container`
2. `gh auth login` → `gh auth setup-git`
3. `gh auth status` en `git push --dry-run` → moet slagen zonder om een
   gebruikersnaam te vragen