### PR TITLE
Verwijder de mermaid-extensie: VS Code rendert het inmiddels zelf

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -44,7 +44,6 @@
       // Claude Code (Anthropic.claude-code): na Rebuild inloggen via de extensie (OAuth of API key).
       "extensions": [
         "DavidAnson.vscode-markdownlint",
-        "bierner.markdown-mermaid",
         "ms-python.python",
         "Anthropic.claude-code"
       ]


### PR DESCRIPTION
Fixes #133

## Wat verandert er

Eén regel weg uit `.devcontainer/devcontainer.json`: `"bierner.markdown-mermaid"` uit de extensielijst.

## Waarom

VS Code 1.131.0 heeft mermaid ingebouwd (`mermaid-markdown-features` zit in de installatie). De extensie draaide daarnaast en pakte hetzelfde ```mermaid-blok op, waarna de markdown-preview een leeg kader met zoomknoppen toonde — het omhulsel van de extensie, met de inhoud bij de ingebouwde renderer.

De extensie is zelf deprecated verklaard, in de changelog bij 1.32.1 van 20 mei 2026: *"Marking as deprecated as the extension has been merged into VS Code as a built-in extension."*

## Gecontroleerd

- Het bestand blijft geldige JSON na verwijdering van het commentaar.
- Het diagram dat de aanleiding was — de ketenplaat in de synthese van #130 — rendert foutloos in mermaid 11 (headless getest, 23 kB SVG, viewBox 1110×820). Het lag niet aan de inhoud.

## Na de merge

De extensie verdwijnt pas bij een Rebuild van de container. Wie hem nu al kwijt wil, verwijdert hem in het Extensions-paneel; de ingebouwde renderer neemt het direct over.

Dezelfde wijziging in `Npuls-OKx/workspace`: https://github.com/Npuls-OKx/workspace/pull/2

🤖 Generated with [Claude Code](https://claude.com/claude-code)