### PR TITLE
Voorstel voor een ID-conventie, met de eisen ernaast

### DIFF
--- a/architecture/agent-artifacts/design-docs/20260804_1900_requirements-id-conventie.md
+++ b/architecture/agent-artifacts/design-docs/20260804_1900_requirements-id-conventie.md
@@ -1,0 +1,170 @@
+# Requirements: conventie voor identificatienummers
+
+Relateert aan: #135, bouwt voort op #130
+
+Eisen aan een conventie voor identificatienummers van OKx-artefacten, opgesteld voordat de conventie zelf wordt uitgewerkt. Elke eis is toetsbaar: er staat bij waaraan je ziet dat eraan is voldaan.
+
+## 1. Aanleiding en gap-analyse
+
+### Wat er al is
+
+| Soort | Bestaande nummering | Waar |
+|---|---|---|
+| Uitgangspunt | `U1` tot en met `U10` | [`uitgangspunten.md`](https://github.com/Npuls-OKx/Public/blob/dev/Koppelvlakspecificaties/uitgangspunten.md) |
+| Interactie | `I1`-`I5` bij planning, `S1`-`S5` bij het studentinformatiesysteem, `L1`-`L6` bij de leeromgeving | §3 van elke koppelingspecificatie |
+| Architectuurbesluit | `0001` tot en met `0024` | [`Referentiemateriaal/adr/`](https://github.com/Npuls-OKx/Public/tree/dev/Referentiemateriaal/adr) |
+| Requirement | `R1` tot en met `R17` | requirements-document keuzes rond onderwijsspecificaties |
+| Schema | `$id` als URI | `Datamodelschema's/*.json` |
+| Informatie-object | **geen** | conceptueel gegevensoverzicht, 33 datarijen |
+| Informatiestroom | **geen** | verspreid over de fasesecties van leerroute 1 |
+
+### Wat ontbreekt
+
+1. **Geen regel bij hernoemen.** Nergens staat wat er gebeurt als een begrip een andere naam krijgt. Dat is geen theoretisch geval: de ankertabel is al een keer herzien, waarbij een kolom werd toegevoegd en de overige kolommen hernummerd.
+2. **Geen regel bij vervallen.** Er is geen status waarmee een ID uit gebruik gaat zonder te verdwijnen.
+3. **Geen controle.** Geen van de bestaande nummeringen wordt machinaal getoetst op dubbelen of dode verwijzingen.
+4. **Vier gewoonten naast elkaar.** `U4`, `I1`, `0021` en `R7` volgen elk een eigen vorm. Een lezer kan aan `R7` niet zien uit welk document het komt.
+5. **Geen plek voor "wij lopen voor op MORA".** Een deel van onze begrippen heeft nog geen equivalent in MORA. Er is geen manier om dat vast te leggen als bewuste stand van zaken in plaats van als omissie.
+
+### Wat géén beperking is
+
+**Bestaande nummers mogen wijzigen.** De conventie wordt nu voor het eerst vastgesteld, dus er is nog geen afspraak die we breken. Een eerdere versie van dit document eiste dat `U1` tot en met `U10`, `I1` tot en met `I5` en de ADR-nummers ongewijzigd moesten kunnen worden opgenomen. Die eis is geschrapt: hij zou vier onderling verschillende nummervormen permanent maken om een eenmalige migratie te vermijden, en dat is de verkeerde ruil.
+
+Vanaf het moment dat de conventie is vastgesteld geldt [R2](#r2--een-id-wordt-nooit-hergebruikt) onverkort. De vrijheid om te hernummeren bestaat dus precies één keer, en nu.
+
+### Beperkingen die gelden
+
+- De documenten worden **gereleased**. Een ID dat een leverancier aanhaalt, moet jaren later nog hetzelfde ding aanwijzen.
+- Bijdragers zijn architecten en onderwijskundigen. Een conventie die een register-lookup vereist voor elke verwijzing, wordt niet gevolgd.
+- Er draait op dit moment **niets in CI**. Elke eis die op machinale controle steunt, veronderstelt dat die controle er komt.
+- Het aantal begrippen groeit: examenplanspecificatie, resultaatstructuren en de vormen van resultaten staan al op de rol.
+
+## 2. Requirements
+
+"MOET" in de zin van RFC 2119.
+
+### R1 — Eén ID per aangehaald ding
+
+Elk artefact dat vanuit een ander document wordt aangehaald, MOET precies één identificatienummer dragen.
+
+*Voorbeeld.* Uitgangspunt U4 (notify-then-pull) wordt aangehaald vanuit de koppelingspecificatie met planning, vanuit de payload-specificatie en straks vanuit een scenario. Alle drie halen hetzelfde ID aan.
+
+*Acceptatie.* Voor elk soort artefact in de tabel van §1 is aanwijsbaar welk veld het ID draagt, en er is geen artefact met twee ID's.
+
+### R2 — Een ID wordt nooit hergebruikt
+
+Een uitgegeven ID MOET permanent aan hetzelfde ding gebonden blijven, ook nadat dat ding is vervallen. Gaten in de reeks zijn toegestaan en verwacht.
+
+*Voorbeeld.* Wordt begrip 014 vervangen door een nieuwe opzet, dan krijgt de opvolger nummer 041 en blijft 014 bestaan met de status vervallen. Nummer 014 komt nooit terug op iets anders.
+
+*Acceptatie.* Een controle meldt het als een ID in het register verdwijnt of van betekenis wisselt ten opzichte van de vorige versie.
+
+*Herkomst.* Dit volgt de vastgelegde praktijk bij Geonovum: *"Design rules have unique and permanent numbers. In the event of design rules being deprecated or restructured, they are removed from the list. Therefore, gaps in the sequence can occur."* ([bron](https://github.com/Geonovum/KP-APIs/blob/master/API-strategie-governance/APIDesignRuleNumbering.md)). Wij wijken op één punt af: bij Geonovum verdwijnt de vervallen regel uit de lijst, bij ons blijft hij staan met status en opvolger. Zie R11.
+
+### R3 — Identiteit staat los van naam
+
+Het deel van het ID dat de identiteit draagt MOET ongewijzigd blijven wanneer de naam of omschrijving van het artefact wijzigt.
+
+*EARS.* WANNEER een begrip wordt hernoemd, MOET het identificerende deel van zijn ID ongewijzigd blijven.
+
+*Voorbeeld.* Heet `Leeronderdeel-specificatie` morgen `Leeractiviteit-specificatie`, dan blijven alle bestaande verwijzingen geldig zonder één document aan te passen.
+
+*Acceptatie.* Een naamswijziging in het register leidt tot nul wijzigingen in verwijzende documenten.
+
+### R4 — Leesbaar zonder register
+
+Een ID MOET in de context waarin het voorkomt te begrijpen zijn zonder het register erbij te pakken.
+
+*Voorbeeld.* Een verwijzing moet zeggen wat voor soort ding wordt aangehaald. `S4` doet dat niet: dat kan een stroom, een stap of een systeem zijn.
+
+*Acceptatie.* Leg een willekeurige verwijzing voor aan iemand die het register niet kent; die kan zeggen wat voor soort ding het is en waar het ongeveer over gaat.
+
+### R5 — Machinaal herkenbaar
+
+Een ID MOET met één reguliere expressie uit vrije tekst, uit JSON en uit een codeblok te halen zijn.
+
+*Acceptatie.* Eén patroon vindt alle ID's in de repository, zonder valse treffers op koppen, ankers, hexkleuren of versienummers.
+
+*Aandachtspunt.* De bestaande issue-controle in `check-conventies.py` laat zien hoe fout dit kan gaan: het patroon daar mist `(#119)` doordat een haakje ervoor wordt uitgesloten. Het ID-patroon moet expliciet op zulke randgevallen worden getoetst.
+
+### R6 — De soort is af te lezen
+
+Uit het ID zelf MOET blijken om wat voor soort artefact het gaat.
+
+*Voorbeeld.* Aan `R7` is niet te zien of het een requirement uit het keuzedocument is of uit een ander document. Aan een ID met een soortaanduiding vooraan wel.
+
+*Acceptatie.* Er bestaan geen twee soorten artefacten waarvan de ID's dezelfde vorm hebben.
+
+### R7 — Een ID identificeert over documentgrenzen heen
+
+Een ID MOET binnen de hele repository naar precies één artefact wijzen. Een nummering die alleen binnen één document uniek is, is geen ID.
+
+*Voorbeeld.* Dit document nummert zijn eisen R1 tot en met R13. Het requirements-document *keuzes rond onderwijsspecificaties* doet dat ook, met R1 tot en met R17. `R7` wijst dus naar twee verschillende dingen. Zonder aanvullende aanduiding kan geen payload, geen schema en geen scenario naar "R7" verwijzen.
+
+*Acceptatie.* Voor elk ID in de repository geldt dat een zoekopdracht op dat ID precies één declaratie oplevert.
+
+*Gevolg.* De conventie moet aangeven welke artefacten een geregistreerd ID krijgen en welke met documentlokale nummering toe kunnen. Niet elk genummerd ding hoeft een ID te zijn.
+
+### R8 — Ruimte voor voorlopen op MORA
+
+Het register MOET kunnen vastleggen dat een begrip nog geen equivalent in MORA heeft, onderscheiden van "nog niet ingevuld".
+
+*Voorbeeld.* `Leergelegenheid` bestaat bij ons en staat nog niet in de MORA-omgeving. Dat is een bewuste stand van zaken, geen omissie, en het is tegelijk invoer voor klus 53.
+
+*Acceptatie.* Er zijn ten minste drie onderscheiden waarden mogelijk: een verwijzing, "bestaat niet in MORA", en "nog niet nagelopen". Een overzicht van alle begrippen zonder MORA-equivalent is met één opdracht te maken.
+
+### R9 — Uitgifte zonder centrale coördinatie
+
+Een nieuw ID MOET uitgegeven kunnen worden door de bijdrager zelf, zonder een beheerder te vragen.
+
+*Voorbeeld.* Wie een begrip toevoegt, kijkt in het register wat het hoogste nummer is en neemt het volgende.
+
+*Acceptatie.* Twee bijdragers die in verschillende branches hetzelfde ID uitgeven, worden door de uniciteitscontrole gemeld. Git vangt dit niet: bij losse bestanden per artefact voegt de merge beide toe zonder conflict.
+
+### R10 — Dubbelen en dode verwijzingen worden gedetecteerd
+
+Elk dubbel ID en elke verwijzing naar een niet-bestaand ID MOET machinaal worden gemeld, met exitcode 1.
+
+*Acceptatie.* Een testgeval met een bewust dubbel ID en een testgeval met een bewuste dode verwijzing falen allebei.
+
+### R11 — Vervallen ID's blijven vindbaar
+
+Een vervallen ID MOET in het register blijven staan, met zijn status en waar van toepassing zijn opvolger.
+
+*Voorbeeld.* Iemand leest een specificatie uit 2026 die naar begrip 014 verwijst en moet in 2029 kunnen achterhalen wat daarmee is gebeurd.
+
+*Acceptatie.* Voor elk vervallen ID is de opvolger of de reden van vervallen in het register te vinden.
+
+### R12 — Het register is de bron
+
+Voor elk soort artefact MOET één register de gezaghebbende lijst van ID's zijn; documenten verwijzen ernaar en houden geen eigen lijst bij.
+
+*Acceptatie.* Er is geen tweede plek waar dezelfde ID-lijst wordt bijgehouden.
+
+### R13 — De vorm belast het document niet
+
+Een ID in de lopende tekst MOET leesbaar blijven voor wie de conventie niet kent, en MAG de weergave op GitHub of in een PDF-export niet verstoren.
+
+*Voorbeeld.* Een gereleased document wordt gelezen door een architect bij een instelling die niets van onze conventie weet. Ziet die pagina eruit als een technisch logbestand, dan is de eis niet gehaald.
+
+*Acceptatie.* Leg een gerenderde pagina met ID's voor aan iemand van buiten; die noemt de ID's niet als storend.
+
+## 3. Wat buiten scope valt
+
+- **Welk gereedschap** de controle uitvoert. De conventie moet met een eigen script van beperkte omvang te controleren zijn; of we later OpenFastTrace of iets anders gebruiken is een aparte afweging.
+- **Het aanleggen van de registers zelf.** Dit document stelt eisen aan de vorm, niet aan de inhoud.
+- **Welke artefacten een ID krijgen.** Dat volgt uit de registers; hier staat alleen wat een ID moet kunnen zodra het bestaat.
+- **De koppeling naar HORA en OEAPI.** Dezelfde mechaniek als de MORA-verwijzing uit R8, maar de invulling is inhoudelijk werk.
+
+## 4. Open vragen voor het kernteam
+
+| Vraag | Waarom het uitmaakt |
+|---|---|
+| Is het identificerende deel het nummer, of de hele tekenreeks inclusief de naam? | Bepaalt of hernoemen gratis is (R3) of een nieuw ID kost |
+| Nummeren we per soort of doorlopend over alles heen? | Per soort leest prettiger; doorlopend maakt een ID uniek zonder de soortaanduiding |
+| Geldt de conventie ook voor ADR's, die al een eigen vierciiferige nummering hebben? | Uniformiteit tegenover R7 |
+| Wie stelt vast dat een begrip vervalt? | R11 veronderstelt een besluitmoment; nu is dat nergens belegd |
+
+## 5. Acceptatie
+
+Vastgesteld door het kernteam OKx. Dit document is geslaagd wanneer twee mensen onafhankelijk van elkaar bij dezelfde voorgestelde conventie tot hetzelfde oordeel komen over of eraan is voldaan.

--- a/architecture/agent-artifacts/design-docs/20260804_1900_voorstel-id-conventie.md
+++ b/architecture/agent-artifacts/design-docs/20260804_1900_voorstel-id-conventie.md
@@ -2,7 +2,7 @@
 
 Relateert aan: #135, bouwt voort op #130. Eisen: [requirements](20260804_1900_requirements-id-conventie.md).
 
-De hoofdconventie is op 12 augustus vastgesteld (zie het plan bij #143): het soort-nummer-patroon geldt voor alle lagen, met voluit en eenduidige soortnamen en een uitbreidbare soortenlijst. De kernteamvragen 2 tot en met 4 in §9 staan nog open; wat er voor de verhuizing naar `Npuls-OKx/Public` moet gebeuren staat in §10.
+De hoofdconventie is op 12 augustus vastgesteld en de schrijfwijze op 13 augustus (zie het plan bij #143): het soort-nummer-patroon geldt voor alle lagen, voluit geschreven met vier cijfers, met eenduidige soortnamen en een uitbreidbare soortenlijst. De kernteamvragen 2 tot en met 4 in §9 staan nog open; wat er voor de verhuizing naar `Npuls-OKx/Public` moet gebeuren staat in §10.
 
 ## 1. De vorm
 
@@ -13,16 +13,16 @@ De hoofdconventie is op 12 augustus vastgesteld (zie het plan bij #143): het soo
 Drie voorbeelden:
 
 ```text
-object-014
-informatiestroom-004
-eis-001
+object-0014
+informatiestroom-0004
+eis-0001
 ```
 
-Meer is het niet. **De naam zit niet in het ID.** Die staat ernaast: als linktekst in markdown, als kop in het registerbestand, als `title` in een schema.
+Meer is het niet. **De naam zit niet in het ID.** Die staat ernaast: als linktekst in markdown, als kop in het registerbestand, als `title` in een schema. **De ouder zit er ook niet in**: een feature onder epic 3 heet `feature-0007`, niet `feature-3.1` (besluit 13 augustus; de boom is strikt en het id draagt geen structuur, zodat opknippen en herordenen nooit hernummert).
 
 ### Waarom de naam er niet in zit
 
-Een eerdere versie van dit voorstel gebruikte `object-014-onderwijseenheid-specificatie`, naar het model van een GitHub-branchnaam. Dat bleek twee eigenschappen te beloven die elkaar uitsluiten.
+Een eerdere versie van dit voorstel gebruikte `object-0014-onderwijseenheid-specificatie`, naar het model van een GitHub-branchnaam. Dat bleek twee eigenschappen te beloven die elkaar uitsluiten.
 
 Zit de naam in de bestandsnaam, dan breekt hernoemen elke verwijzing: `check-links.py` toetst het volledige pad, niet het nummer. Dat is nagemeten met het echte script, en het gaf exitcode 1. De belofte dat hernoemen gratis is ([R3](20260804_1900_requirements-id-conventie.md#r3--identiteit-staat-los-van-naam)) haalde je dus niet.
 
@@ -31,7 +31,7 @@ Bovendien werd het ID onvindbaar. Het patroon dat namen toeliet gaf over beide r
 Met alleen cijfers achter de soort verdwijnen beide problemen. Het patroon wordt:
 
 ```text
-\b(object|informatiestroom|koppeling|interactie|eis|uitgangspunt|wens|architectuur-principe|scenario|besluit)-\d{3}\b
+\b(object|informatiestroom|koppeling|interactie|eis|uitgangspunt|wens|architectuur-principe|scenario|besluit)-\d{4}\b
 ```
 
 Nagemeten over beide repositories: **nul valse treffers**.
@@ -52,7 +52,7 @@ De les uit GitHub blijft overeind, alleen scherper dan ik hem eerst nam. Een iss
 | `scenario-` | Kaderscenario's en varianten | `Kaderscenario's/` |
 | `besluit-` | Architectuurbesluiten | `Referentiemateriaal/adr/` |
 
-Elke soort heeft één doorlopende reeks van drie cijfers met voorloopnullen: ruimte tot 999 per soort, en op naam sorteerbaar. **De soortenlijst is uitbreidbaar**: een nieuwe soort (bijvoorbeeld `wens-`, zodra wensen naast eisen worden vastgelegd) krijgt een eigen voluit geschreven prefix en een eigen register; de conventie zelf wijzigt daar niet voor, alleen het zoekpatroon groeit mee.
+Elke soort heeft één doorlopende reeks van vier cijfers met voorloopnullen: ruimte tot 9999 per soort, en op naam sorteerbaar (besluit 13 augustus: ruim genoeg voor de honderden stories die verwacht worden). **De soortenlijst is uitbreidbaar**: een nieuwe soort (bijvoorbeeld `wens-`, zodra wensen naast eisen worden vastgelegd) krijgt een eigen voluit geschreven prefix en een eigen register; de conventie zelf wijzigt daar niet voor, alleen het zoekpatroon groeit mee.
 
 **Stroom en koppeling zijn niet hetzelfde**, en dat onderscheid is niet van dit voorstel. De [AMIGO-ladder](../../../.agents/skills/amigo-aanpak/SKILL.md) kent drie lagen: een *informatiestroom* is de conceptuele gegevensbeweging uit de scenario-analyse, een *koppeling* is de gestandaardiseerde vorm daarvan tussen twee referentiecomponenten, en een *koppelvlak* is de verzameling koppelingen die één component raken. Dat laatste is vastgelegd in [ADR 0021](https://github.com/Npuls-OKx/Public/blob/dev/Referentiemateriaal/adr/0021-koppeling-versus-koppelvlak-terminologie.md) en in U2. Eén stroom kan uitmonden in één koppeling, of in geen enkele zolang hij nog niet is gestandaardiseerd.
 
@@ -80,15 +80,15 @@ Eén nummer per ding. Een artefact met een geregistreerd ID gebruikt dat ID **oo
 
 ### Regel 1. Een nummer wordt nooit hergebruikt
 
-Ook niet als het artefact vervalt. Vervalt `object-014`, dan blijft dat nummer voor altijd aan dat object gebonden en krijgt de opvolger een nieuw nummer. Gaten in de reeks zijn normaal en verwacht.
+Ook niet als het artefact vervalt. Vervalt `object-0014`, dan blijft dat nummer voor altijd aan dat object gebonden en krijgt de opvolger een nieuw nummer. Gaten in de reeks zijn normaal en verwacht.
 
-De reden is de lezer van over drie jaar. Die vindt in een gearchiveerde specificatie een verwijzing naar `object-014` en moet kunnen achterhalen wat daarmee is gebeurd. Wijst dat nummer inmiddels naar iets anders, dan leest hij stilzwijgend het verkeerde, en dat merkt niemand.
+De reden is de lezer van over drie jaar. Die vindt in een gearchiveerde specificatie een verwijzing naar `object-0014` en moet kunnen achterhalen wat daarmee is gebeurd. Wijst dat nummer inmiddels naar iets anders, dan leest hij stilzwijgend het verkeerde, en dat merkt niemand.
 
 Geonovum legt dezelfde regel vast voor de API Design Rules: *"Design rules have unique and permanent numbers. In the event of design rules being deprecated or restructured, they are removed from the list. Therefore, gaps in the sequence can occur."* ([APIDesignRuleNumbering.md](https://github.com/Geonovum/KP-APIs/blob/master/API-strategie-governance/APIDesignRuleNumbering.md)). Op één punt wijken we bewust af: bij Geonovum verdwijnt de vervallen regel uit de lijst, bij ons blijft hij staan met zijn status en opvolger. Zie regel 3.
 
 ### Regel 2. Een naam mag wijzigen, een nummer niet
 
-Omdat het ID alleen uit soort en nummer bestaat, raakt hernoemen precies één plek: de kop in het registerbestand. Geen enkele verwijzing breekt, want die wijst naar `object-014.md` en die bestandsnaam verandert niet.
+Omdat het ID alleen uit soort en nummer bestaat, raakt hernoemen precies één plek: de kop in het registerbestand. Geen enkele verwijzing breekt, want die wijst naar `object-0014.md` en die bestandsnaam verandert niet.
 
 Voor OKx is dat geen randgeval. We lopen voor op MORA en de terminologie zet zich nog; de ankertabel is al een keer herzien.
 
@@ -122,9 +122,9 @@ Het register is een map met één bestand per artefact, en de bestandsnaam is he
 ```text
 Objecten/
 ├── README.md            gegenereerd overzicht
-├── object-001.md
-├── object-014.md
-└── object-027.md
+├── object-0001.md
+├── object-0014.md
+└── object-0027.md
 ```
 
 Zo'n bestand ziet er zo uit:
@@ -158,7 +158,7 @@ De keerzijde is dat je het overzicht in één oogopslag kwijtraakt. Dat lost een
 
 ```markdown
 De onderwijscatalogus publiceert de
-[onderwijseenheid-specificatie](../Objecten/object-014.md) voor planning.
+[onderwijseenheid-specificatie](../Objecten/object-0014.md) voor planning.
 ```
 
 Voor de lezer is dat een normale link met een leesbare naam. Voor de controle is het een verwijzing naar een bestand dat moet bestaan, en dat toetst `check-links.py` vandaag al.
@@ -169,8 +169,8 @@ Voor de lezer is dat een normale link met een leesbare naam. Voor de controle is
 {
   "$id": "https://okx.npuls.nl/schema/onderwijsspecificatie/alfa",
   "title": "Onderwijsspecificatie",
-  "x-okx-realiseert": ["interactie-001"],
-  "x-okx-object": "object-014"
+  "x-okx-realiseert": ["interactie-0001"],
+  "x-okx-object": "object-0014"
 }
 ```
 
@@ -180,7 +180,7 @@ Onbekende sleutelwoorden worden door de metaschema toegestaan en in de standaard
 
 ```gherkin
 # language: nl
-# realiseert: interactie-001
+# realiseert: interactie-0001
 Functionaliteit: Specificatie planbaar melden
 ```
 
@@ -194,17 +194,17 @@ Het alternatief, vier bestaande nummervormen naast elkaar toelaten om een eenmal
 
 | Bestaat nu | Wordt | Werk |
 |---|---|---|
-| `U1` tot en met `U10` | `uitgangspunt-001` tot en met `uitgangspunt-010` | 61 verwijzingen, plus 27 ankerverwijzingen naar de U-koppen |
-| `R1` tot en met `R17` in het keuzedocument | `eis-001` tot en met `eis-017` | koppen in dat document, 14 verwijzingen uit `payload-regelset.md` |
-| `I1`–`I5`, `S1`–`S5`, `L1`–`L6` | `interactie-001` tot en met `interactie-016` | koppen in drie koppelingspecificaties |
-| `OKx-AP01` tot en met `OKx-AP13` | `architectuur-principe-001` tot en met `architectuur-principe-013` | verwijzingen vanuit de uitgangspunten |
-| ADR-bestandsnamen | `besluit-001.md` tot en met `besluit-024.md` | 56 padverwijzingen in Public |
+| `U1` tot en met `U10` | `uitgangspunt-0001` tot en met `uitgangspunt-0010` | 61 verwijzingen, plus 27 ankerverwijzingen naar de U-koppen |
+| `R1` tot en met `R17` in het keuzedocument | `eis-0001` tot en met `eis-0017` | koppen in dat document, 14 verwijzingen uit `payload-regelset.md` |
+| `I1`–`I5`, `S1`–`S5`, `L1`–`L6` | `interactie-0001` tot en met `interactie-0016` | koppen in drie koppelingspecificaties |
+| `OKx-AP01` tot en met `OKx-AP13` | `architectuur-principe-0001` tot en met `architectuur-principe-0013` | verwijzingen vanuit de uitgangspunten |
+| ADR-bestandsnamen | `besluit-0001.md` tot en met `besluit-0024.md` | 56 padverwijzingen in Public |
 
 Alles mechanisch: een tabel oud naar nieuw, één zoek-en-vervang, en `check-links.py` bewijst dat er niets is blijven hangen.
 
 **Ook de interactienummers.** Die zijn per koppeling uitgedeeld met een eigen letter, `I` bij planning, `S` bij het studentinformatiesysteem, `L` bij de leeromgeving, en daardoor toevallig uniek. Dat loopt stuk zodra er een vierde koppeling komt en iemand opnieuw bij `I` begint. Welke interactie bij welke koppeling hoort, staat in het register.
 
-**Wat je inlevert.** `U5` leest prettiger dan `uitgangspunt-005`, en de uitgangspunten zeggen dat zelf: *"genummerd (U1 tot en met U10) zodat je er in een document of een review naar kunt verwijzen: conform U5"*. Dat is een reële prijs. Daar staat tegenover dat `uitgangspunt-005` klikbaar is, machinaal vindbaar, en niet botst met de R-nummers uit een ander document.
+**Wat je inlevert.** `U5` leest prettiger dan `uitgangspunt-0005`, en de uitgangspunten zeggen dat zelf: *"genummerd (U1 tot en met U10) zodat je er in een document of een review naar kunt verwijzen: conform U5"*. Dat is een reële prijs. Daar staat tegenover dat `uitgangspunt-0005` klikbaar is, machinaal vindbaar, en niet botst met de R-nummers uit een ander document.
 
 ## 6. Het MORA-veld en zijn waarden
 
@@ -227,9 +227,9 @@ Vier controles, elk met exitcode 1 bij een probleem, zodat ze in een workflow pa
 
 | Controle | Faalt wanneer | Testgeval |
 |---|---|---|
-| Uniciteit | Twee bestanden claimen hetzelfde `<soort>-<nummer>` | Twee bestanden `object-014.md` in verschillende mappen |
-| Bestaan | Een verwijzing wijst naar een ID dat niet in het register staat | Een document verwijst naar `object-999` |
-| Onveranderlijkheid | Een ID verdwijnt uit het register of wisselt van betekenis ten opzichte van de vorige versie | Een `object-014.md` wordt verwijderd |
+| Uniciteit | Twee bestanden claimen hetzelfde `<soort>-<nummer>` | Twee bestanden `object-0014.md` in verschillende mappen |
+| Bestaan | Een verwijzing wijst naar een ID dat niet in het register staat | Een document verwijst naar `object-0999` |
+| Onveranderlijkheid | Een ID verdwijnt uit het register of wisselt van betekenis ten opzichte van de vorige versie | Een `object-0014.md` wordt verwijderd |
 | Volledigheid | Een object mist het MORA-veld, of een uitgangspunt wordt nergens aangehaald | Een object zonder MORA-regel |
 
 De laatste bepaalt of de businesslaag levend blijft. Het onderzoek bij #130 concludeert dat een businesslaag verdampt zonder eigenaar **én** zonder controle die faalt als de koppeling breekt. Deze conventie levert het tweede. Het eerste, wie eigenaar is en wie vaststelt dat iets vervalt, staat als open punt in §9.
@@ -247,7 +247,7 @@ De laatste bepaalt of de businesslaag levend blijft. Het onderzoek bij #130 conc
 
 | Vraag | Voorstel | Waarom het uitmaakt |
 |---|---|---|
-| ~~Hernummeren we `U1`–`U10`?~~ **Besloten, 12 augustus**: ja, naar `uitgangspunt-001`–`uitgangspunt-010` (eigen soort, geen `eis-`) | Ja | 61 verwijzingen plus 27 ankers, mechanisch; uitvoering ná de merge van de lopende reviewreeks |
+| ~~Hernummeren we `U1`–`U10`?~~ **Besloten, 12 augustus**: ja, naar `uitgangspunt-0001`–`uitgangspunt-0010` (eigen soort, geen `eis-`) | Ja | 61 verwijzingen plus 27 ankers, mechanisch; uitvoering ná de merge van de lopende reviewreeks |
 | Eén bestand per artefact, of één tabel per soort? | Eén bestand | Reviewbaarheid en merge-conflicten tegenover overzicht |
 | Krijgen de ADR's ook de nieuwe vorm? | Ja | Uniformiteit. Hun nummers zijn al uniek, dus alleen de vorm en de bestandsnaam wijzigen, en dat raakt 56 verwijzingen |
 | Wie stelt vast dat iets vervalt, en wie is eigenaar van een register? | *geen voorstel* | Governance. Regel 3 en de vierde controle veronderstellen allebei een besluitmoment dat nergens is belegd |

--- a/architecture/agent-artifacts/design-docs/20260804_1900_voorstel-id-conventie.md
+++ b/architecture/agent-artifacts/design-docs/20260804_1900_voorstel-id-conventie.md
@@ -1,0 +1,270 @@
+# Voorstel: conventie voor identificatienummers
+
+Relateert aan: #135, bouwt voort op #130. Eisen: [requirements](20260804_1900_requirements-id-conventie.md).
+
+Dit is een voorstel om af te stemmen, geen besluit. Bij akkoord wordt het een regel in `Npuls-OKx/Public`; wat daarvoor moet gebeuren staat in §10.
+
+## 1. De vorm
+
+```text
+<soort>-<nummer>
+```
+
+Drie voorbeelden:
+
+```text
+object-014
+stroom-004
+eis-001
+```
+
+Meer is het niet. **De naam zit niet in het ID.** Die staat ernaast: als linktekst in markdown, als kop in het registerbestand, als `title` in een schema.
+
+### Waarom de naam er niet in zit
+
+Een eerdere versie van dit voorstel gebruikte `object-014-onderwijseenheid-specificatie`, naar het model van een GitHub-branchnaam. Dat bleek twee eigenschappen te beloven die elkaar uitsluiten.
+
+Zit de naam in de bestandsnaam, dan breekt hernoemen elke verwijzing: `check-links.py` toetst het volledige pad, niet het nummer. Dat is nagemeten met het echte script, en het gaf exitcode 1. De belofte dat hernoemen gratis is ([R3](20260804_1900_requirements-id-conventie.md#r3--identiteit-staat-los-van-naam)) haalde je dus niet.
+
+Bovendien werd het ID onvindbaar. Het patroon dat namen toeliet gaf over beide repositories **59 treffers, allemaal vals**: het Nederlands koppelt met streepjes, dus `scenario-uitwerking`, `interactie-analyse` en `eis-voor-eis` matchten allemaal, en er zat zelfs een markdown-anker tussen.
+
+Met alleen cijfers achter de soort verdwijnen beide problemen. Het patroon wordt:
+
+```text
+\b(object|stroom|koppeling|interactie|eis|principe|scenario|besluit)-\d{3}\b
+```
+
+Nagemeten over beide repositories: **nul valse treffers**.
+
+De les uit GitHub blijft overeind, alleen scherper dan ik hem eerst nam. Een issue is `/issues/130`, zonder naam. De naam verschijnt alleen in branchnamen, en die identificeren niets.
+
+### De soorten
+
+| Prefix | Waarvoor | Waar het register staat |
+|---|---|---|
+| `object-` | Informatie-objecten uit de ankertabel | `Objecten/` |
+| `stroom-` | Informatiestromen: conceptuele gegevensbeweging tussen ketenpartners | `Informatiestromen/` |
+| `koppeling-` | Gestandaardiseerde informatiestroom tussen twee referentiecomponenten | de map van de koppelingspecificatie |
+| `interactie-` | Interacties binnen één koppeling | idem |
+| `eis-` | Uitgangspunten en normatieve eisen | `Eisen/` |
+| `principe-` | Architectuurprincipes `OKx-AP01` tot en met `OKx-AP13` | `Referentiemateriaal/principes/` |
+| `scenario-` | Kaderscenario's en varianten | `Kaderscenario's/` |
+| `besluit-` | Architectuurbesluiten | `Referentiemateriaal/adr/` |
+
+Elke soort heeft één doorlopende reeks van drie cijfers met voorloopnullen: ruimte tot 999 per soort, en op naam sorteerbaar.
+
+**Stroom en koppeling zijn niet hetzelfde**, en dat onderscheid is niet van dit voorstel. De [AMIGO-ladder](../../../.agents/skills/amigo-aanpak/SKILL.md) kent drie lagen: een *informatiestroom* is de conceptuele gegevensbeweging uit de scenario-analyse, een *koppeling* is de gestandaardiseerde vorm daarvan tussen twee referentiecomponenten, en een *koppelvlak* is de verzameling koppelingen die één component raken. Dat laatste is vastgelegd in [ADR 0021](https://github.com/Npuls-OKx/Public/blob/dev/Referentiemateriaal/adr/0021-koppeling-versus-koppelvlak-terminologie.md) en in U2. Eén stroom kan uitmonden in één koppeling, of in geen enkele zolang hij nog niet is gestandaardiseerd.
+
+## 2. Niet alles krijgt een ID
+
+Dit is de regel die het meeste werk bespaart. Ze volgt uit [R7](20260804_1900_requirements-id-conventie.md#r7--een-id-identificeert-over-documentgrenzen-heen):
+
+> **Een artefact krijgt een geregistreerd ID zodra iets buiten zijn eigen document ernaar verwijst. Zolang dat niet zo is, volstaat lokale nummering.**
+
+Waarom dat nodig is: het requirements-document hiernaast nummert zijn eisen R1 tot en met R13, en het requirements-document *keuzes rond onderwijsspecificaties* doet hetzelfde met R1 tot en met R17. `R7` wijst dus naar twee verschillende dingen. Zolang die nummers alleen binnen hun eigen document worden gelezen is dat prima. Zodra een payload eraan refereert, is het dubbelzinnig, en dat gebeurt al: `payload-regelset.md` haalt veertien R-nummers uit het keuzedocument aan.
+
+| Wel een geregistreerd ID | Geen |
+|---|---|
+| Informatie-objecten, stromen, koppelingen, interacties | Eisen in een analysedocument die nergens buiten worden aangehaald |
+| Uitgangspunten, principes, besluiten | Koppelvlakken: die zijn de optelsom per component en worden aangeduid met dat component |
+| Kaderscenario's en varianten | Schema's: die hebben al een `$id` als URI, en twee ID's per artefact mag niet ([R1](20260804_1900_requirements-id-conventie.md#r1--eén-id-per-aangehaald-ding)) |
+| | Referentiecomponenten: aangeduid met hun afkorting, die al vastligt in de instap-README |
+| | Persona's, waardenlijsten, gherkin-scenario's, tussenkoppen, tabelrijen |
+
+Vier daarvan zijn bewuste keuzes en geen omissies. **Schema's** dragen al een `$id`; dat is hun ID en er komt geen tweede naast. **Referentiecomponenten** hebben met OC, P&R, SIS, SKS en LMS een vaste, gepubliceerde afkorting die al als sleutel werkt. **Koppelvlakken** zijn geen artefact maar een verzameling. **Waardenlijsten** krijgen er pas een zodra de vocabulairespecificatie er is; dat is een eigen traject.
+
+Eén nummer per ding. Een artefact met een geregistreerd ID gebruikt dat ID **ook als kop in zijn eigen document**; er komt geen tweede, lokale nummering naast.
+
+## 3. De regels
+
+### Regel 1. Een nummer wordt nooit hergebruikt
+
+Ook niet als het artefact vervalt. Vervalt `object-014`, dan blijft dat nummer voor altijd aan dat object gebonden en krijgt de opvolger een nieuw nummer. Gaten in de reeks zijn normaal en verwacht.
+
+De reden is de lezer van over drie jaar. Die vindt in een gearchiveerde specificatie een verwijzing naar `object-014` en moet kunnen achterhalen wat daarmee is gebeurd. Wijst dat nummer inmiddels naar iets anders, dan leest hij stilzwijgend het verkeerde, en dat merkt niemand.
+
+Geonovum legt dezelfde regel vast voor de API Design Rules: *"Design rules have unique and permanent numbers. In the event of design rules being deprecated or restructured, they are removed from the list. Therefore, gaps in the sequence can occur."* ([APIDesignRuleNumbering.md](https://github.com/Geonovum/KP-APIs/blob/master/API-strategie-governance/APIDesignRuleNumbering.md)). Op één punt wijken we bewust af: bij Geonovum verdwijnt de vervallen regel uit de lijst, bij ons blijft hij staan met zijn status en opvolger. Zie regel 3.
+
+### Regel 2. Een naam mag wijzigen, een nummer niet
+
+Omdat het ID alleen uit soort en nummer bestaat, raakt hernoemen precies één plek: de kop in het registerbestand. Geen enkele verwijzing breekt, want die wijst naar `object-014.md` en die bestandsnaam verandert niet.
+
+Voor OKx is dat geen randgeval. We lopen voor op MORA en de terminologie zet zich nog; de ankertabel is al een keer herzien.
+
+### Regel 3. Vervallen is een status, geen verwijdering
+
+```mermaid
+stateDiagram-v2
+    [*] --> concept: nummer uitgegeven
+    concept --> vastgesteld: kernteam stelt vast
+    vastgesteld --> vervallen: besluit tot vervallen
+    vervallen --> [*]: nummer blijft bezet
+    note right of vervallen
+        Blijft in het register staan,
+        met reden en opvolger.
+        Het nummer komt nooit terug.
+    end note
+```
+
+### Regel 4. Wie het artefact toevoegt, geeft het nummer uit
+
+Geen beheerder en geen aanvraag: kijk in het register wat het hoogste nummer is en neem het volgende.
+
+Geven twee mensen in verschillende branches hetzelfde nummer uit, dan lost git dat **niet** op: bij losse bestanden per artefact voegt de merge beide gewoon toe. De uniciteitscontrole uit §7 moet dat vangen. Wat niet mag gebeuren is dat het stil goed lijkt te gaan.
+
+## 4. Waar een ID staat
+
+### De declaratie: één bestand per artefact
+
+Het register is een map met één bestand per artefact, en de bestandsnaam is het ID:
+
+```text
+Objecten/
+├── README.md            gegenereerd overzicht
+├── object-001.md
+├── object-014.md
+└── object-027.md
+```
+
+Zo'n bestand ziet er zo uit:
+
+```markdown
+# Onderwijseenheid-specificatie
+
+De specificatie van de fundamentele eenheid waarin onderwijs wordt ontworpen en
+aangeboden, in de vorm van een samenhangend stelsel van beoogde leeruitkomsten,
+leeronderdelen en toetsonderdelen.
+
+| | |
+|---|---|
+| Vlak | onderwijsspecificatie |
+| Niveau in het kwalificatiekader | kerntaak |
+| Status | vastgesteld |
+| MORA | nog niet in MORA |
+| MORA-HORA-afstemming | Onderwijseenheid |
+| OEAPI | `Course` |
+```
+
+De bestandsnaam draagt geen naam, dus hernoemen raakt alleen de kop hierboven.
+
+**Waarom losse bestanden en niet één tabel.** Een wijziging aan één object is dan een diff van één bestand, te reviewen zonder de rest te lezen. Bij één grote tabel raakt elke wijziging hetzelfde bestand, en met meerdere mensen tegelijk levert dat merge-conflicten op precies het moment dat het druk is. Het aantal objecten groeit bovendien: examenplanspecificatie, resultaatstructuren en de vormen van resultaten staan al op de rol.
+
+De keerzijde is dat je het overzicht in één oogopslag kwijtraakt. Dat lost een `README.md` op die uit de bestanden wordt gegenereerd, zodat de tabel er wel is maar niemand hem bijhoudt.
+
+*Alternatief om te bespreken:* één tabelbestand per soort. Simpeler om aan te leggen, en voor 33 objecten goed te overzien. De afweging is of we verwachten dat meerdere mensen tegelijk aan objecten werken.
+
+### De verwijzing in een document
+
+```markdown
+De onderwijscatalogus publiceert de
+[onderwijseenheid-specificatie](../Objecten/object-014.md) voor planning.
+```
+
+Voor de lezer is dat een normale link met een leesbare naam. Voor de controle is het een verwijzing naar een bestand dat moet bestaan, en dat toetst `check-links.py` vandaag al.
+
+### De verwijzing vanuit een JSON Schema
+
+```json
+{
+  "$id": "https://okx.npuls.nl/schema/onderwijsspecificatie/alfa",
+  "title": "Onderwijsspecificatie",
+  "x-okx-realiseert": ["interactie-001"],
+  "x-okx-object": "object-014"
+}
+```
+
+Onbekende sleutelwoorden worden door de metaschema toegestaan en in de standaardmodus genegeerd. Let op: in strikte modus, bijvoorbeeld `ajv --strict`, melden validators een onbekend sleutelwoord als fout en moet het bekend worden gemaakt. Het `x-`-voorvoegsel is overigens een OpenAPI-conventie; JSON Schema kent daarvoor `$vocabulary`.
+
+### De verwijzing in een scenario
+
+```gherkin
+# language: nl
+# realiseert: interactie-001
+Functionaliteit: Specificatie planbaar melden
+```
+
+Een gherkin-bestand krijgt zelf geen ID. Het draagt alleen een verwijzing naar wat het toetst.
+
+## 5. Wat dit betekent voor wat er al ligt
+
+We hernummeren, één keer. De conventie wordt nu voor het eerst vastgesteld, dus er is nog geen afspraak die we breken. Vanaf vaststelling geldt regel 1 onverkort: de vrijheid om te hernummeren bestaat precies één keer, en dat is nu.
+
+Het alternatief, vier bestaande nummervormen naast elkaar toelaten om een eenmalige migratie te vermijden, zou die vormen permanent maken. Dat is de verkeerde ruil.
+
+| Bestaat nu | Wordt | Werk |
+|---|---|---|
+| `U1` tot en met `U10` | `eis-001` tot en met `eis-010` | 61 verwijzingen, plus 27 ankerverwijzingen naar de U-koppen |
+| `R1` tot en met `R17` in het keuzedocument | `eis-011` tot en met `eis-027` | koppen in dat document, 14 verwijzingen uit `payload-regelset.md` |
+| `I1`–`I5`, `S1`–`S5`, `L1`–`L6` | `interactie-001` tot en met `interactie-016` | koppen in drie koppelingspecificaties |
+| `OKx-AP01` tot en met `OKx-AP13` | `principe-001` tot en met `principe-013` | verwijzingen vanuit de uitgangspunten |
+| ADR-bestandsnamen | `besluit-001.md` tot en met `besluit-024.md` | 56 padverwijzingen in Public |
+
+Alles mechanisch: een tabel oud naar nieuw, één zoek-en-vervang, en `check-links.py` bewijst dat er niets is blijven hangen.
+
+**Ook de interactienummers.** Die zijn per koppeling uitgedeeld met een eigen letter, `I` bij planning, `S` bij het studentinformatiesysteem, `L` bij de leeromgeving, en daardoor toevallig uniek. Dat loopt stuk zodra er een vierde koppeling komt en iemand opnieuw bij `I` begint. Welke interactie bij welke koppeling hoort, staat in het register.
+
+**Wat je inlevert.** `U5` leest prettiger dan `eis-005`, en de uitgangspunten zeggen dat zelf: *"genummerd (U1 tot en met U10) zodat je er in een document of een review naar kunt verwijzen: conform U5"*. Dat is een reële prijs. Daar staat tegenover dat `eis-005` klikbaar is, machinaal vindbaar, en niet botst met de R-nummers uit een ander document.
+
+## 6. Het MORA-veld en zijn waarden
+
+Een deel van onze objecten staat nog niet in MORA. Dat is een stand van zaken en geen omissie, en het veld moet dat onderscheid dragen ([R8](20260804_1900_requirements-id-conventie.md#r8--ruimte-voor-voorlopen-op-mora)):
+
+| Waarde | Betekenis |
+|---|---|
+| een URI | Vastgesteld equivalent in MORA |
+| `nog niet in MORA` | Wij lopen voor. Dit is invoer voor de MORA-HORA-afstemming |
+| `niet van toepassing` | Komt daar niet, bijvoorbeeld een OKx-eigen constructie |
+| veld ontbreekt | Nog niet nagelopen. Dat is een fout en de controle meldt het |
+
+Het overzicht van alles met `nog niet in MORA` is daarmee met één opdracht te maken, en dat lijstje is de agenda richting de afstemming. Het onderhoudt zichzelf.
+
+Stand van zaken vandaag: het conceptueel gegevensoverzicht in leerroute 1 telt **33 datarijen**, waarvan er **vier** een MORA-verwijzing dragen, alle vier in het vlak kwalificatiekader. De overige 29 hebben er geen.
+
+## 7. Wat de controle doet
+
+Vier controles, elk met exitcode 1 bij een probleem, zodat ze in een workflow passen zoals de bestaande scripts.
+
+| Controle | Faalt wanneer | Testgeval |
+|---|---|---|
+| Uniciteit | Twee bestanden claimen hetzelfde `<soort>-<nummer>` | Twee bestanden `object-014.md` in verschillende mappen |
+| Bestaan | Een verwijzing wijst naar een ID dat niet in het register staat | Een document verwijst naar `object-999` |
+| Onveranderlijkheid | Een ID verdwijnt uit het register of wisselt van betekenis ten opzichte van de vorige versie | Een `object-014.md` wordt verwijderd |
+| Volledigheid | Een object mist het MORA-veld, of een uitgangspunt wordt nergens aangehaald | Een object zonder MORA-regel |
+
+De laatste bepaalt of de businesslaag levend blijft. Het onderzoek bij #130 concludeert dat een businesslaag verdampt zonder eigenaar **én** zonder controle die faalt als de koppeling breekt. Deze conventie levert het tweede. Het eerste, wie eigenaar is en wie vaststelt dat iets vervalt, staat als open punt in §9.
+
+**Wat de bestaande scripts wel en niet kunnen.** `check-links.py` dekt de markdown-verwijzingen, en dat is vandaag al zo. Het ziet echter alleen `*.md` en alleen `](...)`; de verwijzingen in JSON en in gherkin uit §4 zijn voor dat script onzichtbaar. Die vragen een eigen controle, geschat op zo'n honderd regels.
+
+## 8. Wat we hiermee niet oplossen
+
+- **Het gereedschap.** Dit werkt met een eigen script. Of we later OpenFastTrace gebruiken is een losse afweging; ID's zijn tekst, dus die stap blijft open.
+- **Welke artefacten een ID krijgen.** §2 geeft de regel, de registers geven de invulling.
+- **De koppeling naar HORA en OEAPI.** Zelfde mechaniek als het MORA-veld, maar de invulling is inhoudelijk werk.
+- **De vocabulairespecificatie.** Waardenlijsten krijgen pas een ID als die er is.
+
+## 9. Te bespreken met het kernteam
+
+| Vraag | Voorstel | Waarom het uitmaakt |
+|---|---|---|
+| Hernummeren we `U1`–`U10` naar `eis-001`–`eis-010`? | Ja | 61 verwijzingen plus 27 ankers, mechanisch. Het alternatief maakt vier nummervormen permanent. Kost de leesbaarheid van "conform U5" |
+| Eén bestand per artefact, of één tabel per soort? | Eén bestand | Reviewbaarheid en merge-conflicten tegenover overzicht |
+| Krijgen de ADR's ook de nieuwe vorm? | Ja | Uniformiteit. Hun nummers zijn al uniek, dus alleen de vorm en de bestandsnaam wijzigen, en dat raakt 56 verwijzingen |
+| Wie stelt vast dat iets vervalt, en wie is eigenaar van een register? | *geen voorstel* | Governance. Regel 3 en de vierde controle veronderstellen allebei een besluitmoment dat nergens is belegd |
+
+De zwaarste is de eerste. Wie hernummeren van de uitgangspunten te duur vindt, kan voorstellen ze hun `U`-nummer te laten houden. Dan zijn er twee nummervormen binnen dezelfde soort en is de keuze half. Ik zou hem heel maken, juist omdat dit het enige moment is waarop het mag.
+
+## 10. Van voorstel naar regel in Public
+
+Bij akkoord verhuist de conventie naar `Npuls-OKx/Public`. Dit document kan daar niet ongewijzigd heen:
+
+- de issueverwijzingen bovenaan moeten weg en de aanleiding moet in de inleiding worden uitgeschreven;
+- de inleiding moet zelfdragend worden met aanleiding, context, doel en scope (U10);
+- de datumprefix in de bestandsnaam vervalt;
+- de links naar `Public` worden relatief.
+
+`check-conventies.py` keurt de huidige vorm af, en terecht: dit is een meta-artefact. Het overhevelen is een eigen stap en geen bijproduct van de vaststelling.
+
+Losse punten die hierbij horen maar niet in dit voorstel thuishoren, elk met een eigen issue:
+
+- **U8 en `$comment`.** De volwassenheid van een schema staat nu in `$comment`, en `json-tree.py` regel 227 leest dat veld uit. Overstappen op een eigen sleutel is verdedigbaar zodra een script het uitleest, maar het is een wijziging aan Public met een scriptwijziging eraan vast.
+- **De vocabulairespecificatie**, die als AMIGO-product ontbreekt.

--- a/architecture/agent-artifacts/design-docs/20260804_1900_voorstel-id-conventie.md
+++ b/architecture/agent-artifacts/design-docs/20260804_1900_voorstel-id-conventie.md
@@ -2,7 +2,7 @@
 
 Relateert aan: #135, bouwt voort op #130. Eisen: [requirements](20260804_1900_requirements-id-conventie.md).
 
-Dit is een voorstel om af te stemmen, geen besluit. Bij akkoord wordt het een regel in `Npuls-OKx/Public`; wat daarvoor moet gebeuren staat in §10.
+De hoofdconventie is op 12 augustus vastgesteld (zie het plan bij #143): het soort-nummer-patroon geldt voor alle lagen, met voluit en eenduidige soortnamen en een uitbreidbare soortenlijst. De kernteamvragen 2 tot en met 4 in §9 staan nog open; wat er voor de verhuizing naar `Npuls-OKx/Public` moet gebeuren staat in §10.
 
 ## 1. De vorm
 
@@ -14,7 +14,7 @@ Drie voorbeelden:
 
 ```text
 object-014
-stroom-004
+informatiestroom-004
 eis-001
 ```
 
@@ -31,7 +31,7 @@ Bovendien werd het ID onvindbaar. Het patroon dat namen toeliet gaf over beide r
 Met alleen cijfers achter de soort verdwijnen beide problemen. Het patroon wordt:
 
 ```text
-\b(object|stroom|koppeling|interactie|eis|principe|scenario|besluit)-\d{3}\b
+\b(object|informatiestroom|koppeling|interactie|eis|uitgangspunt|wens|architectuur-principe|scenario|besluit)-\d{3}\b
 ```
 
 Nagemeten over beide repositories: **nul valse treffers**.
@@ -43,15 +43,16 @@ De les uit GitHub blijft overeind, alleen scherper dan ik hem eerst nam. Een iss
 | Prefix | Waarvoor | Waar het register staat |
 |---|---|---|
 | `object-` | Informatie-objecten uit de ankertabel | `Objecten/` |
-| `stroom-` | Informatiestromen: conceptuele gegevensbeweging tussen ketenpartners | `Informatiestromen/` |
+| `informatiestroom-` | Informatiestromen: conceptuele gegevensbeweging tussen ketenpartners | `Informatiestromen/` |
 | `koppeling-` | Gestandaardiseerde informatiestroom tussen twee referentiecomponenten | de map van de koppelingspecificatie |
 | `interactie-` | Interacties binnen één koppeling | idem |
-| `eis-` | Uitgangspunten en normatieve eisen | `Eisen/` |
-| `principe-` | Architectuurprincipes `OKx-AP01` tot en met `OKx-AP13` | `Referentiemateriaal/principes/` |
+| `eis-` | Normatieve eisen (requirements) | `Eisen/` |
+| `uitgangspunt-` | Uitgangspunten (nu `U1` tot en met `U10`) | `Koppelvlakspecificaties/` (de uitgangspuntenlijst) |
+| `architectuur-principe-` | Architectuurprincipes `OKx-AP01` tot en met `OKx-AP13` | `Referentiemateriaal/principes/` |
 | `scenario-` | Kaderscenario's en varianten | `Kaderscenario's/` |
 | `besluit-` | Architectuurbesluiten | `Referentiemateriaal/adr/` |
 
-Elke soort heeft één doorlopende reeks van drie cijfers met voorloopnullen: ruimte tot 999 per soort, en op naam sorteerbaar.
+Elke soort heeft één doorlopende reeks van drie cijfers met voorloopnullen: ruimte tot 999 per soort, en op naam sorteerbaar. **De soortenlijst is uitbreidbaar**: een nieuwe soort (bijvoorbeeld `wens-`, zodra wensen naast eisen worden vastgelegd) krijgt een eigen voluit geschreven prefix en een eigen register; de conventie zelf wijzigt daar niet voor, alleen het zoekpatroon groeit mee.
 
 **Stroom en koppeling zijn niet hetzelfde**, en dat onderscheid is niet van dit voorstel. De [AMIGO-ladder](../../../.agents/skills/amigo-aanpak/SKILL.md) kent drie lagen: een *informatiestroom* is de conceptuele gegevensbeweging uit de scenario-analyse, een *koppeling* is de gestandaardiseerde vorm daarvan tussen twee referentiecomponenten, en een *koppelvlak* is de verzameling koppelingen die één component raken. Dat laatste is vastgelegd in [ADR 0021](https://github.com/Npuls-OKx/Public/blob/dev/Referentiemateriaal/adr/0021-koppeling-versus-koppelvlak-terminologie.md) en in U2. Eén stroom kan uitmonden in één koppeling, of in geen enkele zolang hij nog niet is gestandaardiseerd.
 
@@ -193,17 +194,17 @@ Het alternatief, vier bestaande nummervormen naast elkaar toelaten om een eenmal
 
 | Bestaat nu | Wordt | Werk |
 |---|---|---|
-| `U1` tot en met `U10` | `eis-001` tot en met `eis-010` | 61 verwijzingen, plus 27 ankerverwijzingen naar de U-koppen |
-| `R1` tot en met `R17` in het keuzedocument | `eis-011` tot en met `eis-027` | koppen in dat document, 14 verwijzingen uit `payload-regelset.md` |
+| `U1` tot en met `U10` | `uitgangspunt-001` tot en met `uitgangspunt-010` | 61 verwijzingen, plus 27 ankerverwijzingen naar de U-koppen |
+| `R1` tot en met `R17` in het keuzedocument | `eis-001` tot en met `eis-017` | koppen in dat document, 14 verwijzingen uit `payload-regelset.md` |
 | `I1`–`I5`, `S1`–`S5`, `L1`–`L6` | `interactie-001` tot en met `interactie-016` | koppen in drie koppelingspecificaties |
-| `OKx-AP01` tot en met `OKx-AP13` | `principe-001` tot en met `principe-013` | verwijzingen vanuit de uitgangspunten |
+| `OKx-AP01` tot en met `OKx-AP13` | `architectuur-principe-001` tot en met `architectuur-principe-013` | verwijzingen vanuit de uitgangspunten |
 | ADR-bestandsnamen | `besluit-001.md` tot en met `besluit-024.md` | 56 padverwijzingen in Public |
 
 Alles mechanisch: een tabel oud naar nieuw, één zoek-en-vervang, en `check-links.py` bewijst dat er niets is blijven hangen.
 
 **Ook de interactienummers.** Die zijn per koppeling uitgedeeld met een eigen letter, `I` bij planning, `S` bij het studentinformatiesysteem, `L` bij de leeromgeving, en daardoor toevallig uniek. Dat loopt stuk zodra er een vierde koppeling komt en iemand opnieuw bij `I` begint. Welke interactie bij welke koppeling hoort, staat in het register.
 
-**Wat je inlevert.** `U5` leest prettiger dan `eis-005`, en de uitgangspunten zeggen dat zelf: *"genummerd (U1 tot en met U10) zodat je er in een document of een review naar kunt verwijzen: conform U5"*. Dat is een reële prijs. Daar staat tegenover dat `eis-005` klikbaar is, machinaal vindbaar, en niet botst met de R-nummers uit een ander document.
+**Wat je inlevert.** `U5` leest prettiger dan `uitgangspunt-005`, en de uitgangspunten zeggen dat zelf: *"genummerd (U1 tot en met U10) zodat je er in een document of een review naar kunt verwijzen: conform U5"*. Dat is een reële prijs. Daar staat tegenover dat `uitgangspunt-005` klikbaar is, machinaal vindbaar, en niet botst met de R-nummers uit een ander document.
 
 ## 6. Het MORA-veld en zijn waarden
 
@@ -246,12 +247,12 @@ De laatste bepaalt of de businesslaag levend blijft. Het onderzoek bij #130 conc
 
 | Vraag | Voorstel | Waarom het uitmaakt |
 |---|---|---|
-| Hernummeren we `U1`–`U10` naar `eis-001`–`eis-010`? | Ja | 61 verwijzingen plus 27 ankers, mechanisch. Het alternatief maakt vier nummervormen permanent. Kost de leesbaarheid van "conform U5" |
+| ~~Hernummeren we `U1`–`U10`?~~ **Besloten, 12 augustus**: ja, naar `uitgangspunt-001`–`uitgangspunt-010` (eigen soort, geen `eis-`) | Ja | 61 verwijzingen plus 27 ankers, mechanisch; uitvoering ná de merge van de lopende reviewreeks |
 | Eén bestand per artefact, of één tabel per soort? | Eén bestand | Reviewbaarheid en merge-conflicten tegenover overzicht |
 | Krijgen de ADR's ook de nieuwe vorm? | Ja | Uniformiteit. Hun nummers zijn al uniek, dus alleen de vorm en de bestandsnaam wijzigen, en dat raakt 56 verwijzingen |
 | Wie stelt vast dat iets vervalt, en wie is eigenaar van een register? | *geen voorstel* | Governance. Regel 3 en de vierde controle veronderstellen allebei een besluitmoment dat nergens is belegd |
 
-De zwaarste is de eerste. Wie hernummeren van de uitgangspunten te duur vindt, kan voorstellen ze hun `U`-nummer te laten houden. Dan zijn er twee nummervormen binnen dezelfde soort en is de keuze half. Ik zou hem heel maken, juist omdat dit het enige moment is waarop het mag.
+De eerste vraag is op 12 augustus beslecht: hernummeren, heel en in één keer, met `uitgangspunt-` als eigen soort. De uitvoering wacht op de merge van de lopende reviewreeks (meta-PR 131 en de gestapelde refactors), zodat lopende reviews niet breken.
 
 ## 10. Van voorstel naar regel in Public
 


### PR DESCRIPTION
Fixes #135. Bouwt voort op #130 en staat daarom op die branch; GitHub richt de basis vanzelf op `dev` zodra #131 is gemerged.

## Wat dit is

Een voorstel om met het kernteam af te stemmen, plus de eisen waaraan het is getoetst. **Geen implementatie**: er worden hier geen ID's uitgedeeld en geen registers aangelegd.

## De conventie in één regel

```text
<soort>-<nummer>
```

`object-014`, `stroom-004`, `eis-001`. De naam zit er niet in; die staat ernaast als linktekst, kop of `title`.

## Product-flow

Requirements → uitwerking → tester en semantiek-reviewer in verse contexten → herziening. **Beide reviews gaven eerst een onvoldoende.** Wat dat opleverde:

| Bevinding | Gevolg |
|---|---|
| De eerste opzet zette de naam in de bestandsnaam. Hernoemen breekt dan elke verwijzing, want `check-links.py` toetst het pad. Nagemeten met het echte script: exitcode 1 | Naam volledig uit het ID |
| Het patroon dat namen toeliet gaf **59 treffers over beide repositories, allemaal vals**: `scenario-uitwerking`, `interactie-analyse`, `eis-voor-eis`, en zelfs een markdown-anker | Alleen cijfers achter de soort. Hetzelfde patroon geeft nu **nul** valse treffers |
| `begrip-` botst met het OKx-gebruik van "begrip" voor de bredere woordenschat | Prefix `object-` |
| `stroom-` las als synoniem van `koppeling`, dat net in ADR 0021 is vastgelegd | Onderscheid onderbouwd met de AMIGO-ladder; `koppeling-` als eigen soort toegevoegd |
| Vier soorten ontbraken | `principe-` toegevoegd; van schema's, referentiecomponenten, koppelvlakken, persona's en waardenlijsten staat nu expliciet dat ze géén eigen ID krijgen, met reden |
| Drie feitelijke fouten | 33 datarijen in plaats van 28, kwalificatiekader is een *vlak* en geen kolom, en het registervoorbeeld gebruikte de MORA-URI van `Kerntaak` |

Eén reviewbevinding is **niet** overgenomen: de claim dat "vooraf" niet in de naam van R7 zou staan. Het keuzedocument heeft letterlijk *"Voorwaarde vooraf in behaalde leeruitkomsten"*.

## Wat er wijzigde ten opzichte van het gesprek

R7 in het requirements-document was eerst "geen migratie van bestaande nummers". Die eis is geschrapt: de conventie wordt nu voor het eerst vastgesteld, dus er is nog geen afspraak die we breken, en vier nummervormen permanent maken om één migratie te vermijden is de verkeerde ruil. De nieuwe R7 eist dat een ID over documentgrenzen heen identificeert. Daaruit volgt de regel die het meeste werk bespaart: **niet alles krijgt een ID**, alleen wat van buiten zijn eigen document wordt aangehaald.

## Vier vragen voor het kernteam

1. Hernummeren we `U1`–`U10` naar `eis-001`–`eis-010`? Dat raakt 61 verwijzingen plus 27 ankers, en kost de leesbaarheid van "conform U5".
2. Eén bestand per artefact, of één tabel per soort?
3. Krijgen de ADR's ook de nieuwe vorm? Dat raakt 56 padverwijzingen.
4. Wie stelt vast dat iets vervalt, en wie is eigenaar van een register? Hier heb ik bewust geen voorstel gedaan: het is governance en het is nergens belegd.

## Gecontroleerd

- `validate-docs.py` schoon op beide documenten
- Het toestandsdiagram getoetst met een headless mermaid-render
- Alle kruisverwijzingen tussen de twee documenten nagelopen; één dood anker gevonden en hersteld
- Het voorgestelde patroon gedraaid over beide repositories: nul valse treffers

## Nog niet gedaan

Het overhevelen naar Public is als eigen stap in §10 beschreven, niet uitgevoerd: de issueverwijzingen moeten eruit, de inleiding moet zelfdragend worden en de datumprefix vervalt. De U8-wijziging rond `$comment` is afgesplitst, want die kost ook een wijziging aan `json-tree.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)